### PR TITLE
PAYLAPMEXT-240 Correctif PluginConf et corrections sonar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,3 +99,9 @@ test {
     useJUnitPlatform()
     exclude('**/*IT.class')
 }
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+    }
+}

--- a/monext.gradle
+++ b/monext.gradle
@@ -48,7 +48,7 @@ publishing {
 
 sonarqube {
     properties {
-        property "sonar.jacoco.reportPaths", "${project.buildDir}/jacoco/test.exec"
+        property "sonar.coverage.jacoco.xmlReportPaths", "${project.buildDir}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dependencyCheck.reportPath", "${project.buildDir}/reports/dependency-check-report.xml"
         property 'sonar.dependencyCheck.htmlReportPath', "${project.buildDir}/reports/dependency-check-report.html"
     }

--- a/src/main/java/com/payline/payment/natixis/service/GenericPaymentService.java
+++ b/src/main/java/com/payline/payment/natixis/service/GenericPaymentService.java
@@ -7,7 +7,6 @@ import com.payline.payment.natixis.bean.business.payment.*;
 import com.payline.payment.natixis.bean.configuration.RequestConfiguration;
 import com.payline.payment.natixis.exception.InvalidDataException;
 import com.payline.payment.natixis.exception.PluginException;
-import com.payline.payment.natixis.service.impl.PaymentServiceImpl;
 import com.payline.payment.natixis.utils.Constants;
 import com.payline.payment.natixis.utils.PluginUtils;
 import com.payline.payment.natixis.utils.http.NatixisHttpClient;
@@ -27,7 +26,7 @@ import java.text.NumberFormat;
 import java.util.*;
 
 public class GenericPaymentService {
-    private static final Logger LOGGER = LogManager.getLogger(PaymentServiceImpl.class);
+    private static final Logger LOGGER = LogManager.getLogger(GenericPaymentService.class);
     private ConfigProperties config = ConfigProperties.getInstance();
     private NatixisHttpClient natixisHttpClient = NatixisHttpClient.getInstance();
 

--- a/src/main/java/com/payline/payment/natixis/service/impl/ConfigurationServiceImpl.java
+++ b/src/main/java/com/payline/payment/natixis/service/impl/ConfigurationServiceImpl.java
@@ -268,12 +268,11 @@ public class ConfigurationServiceImpl implements ConfigurationService {
             // Retrieve account service providers list
             NatixisBanksResponse banks = natixisHttpClient.banks(requestConfiguration);
 
-            // get oldKey or generate first key
-            String key;
-            if (PluginUtils.isEmpty(retrievePluginConfigurationRequest.getPluginConfiguration())) {
+
+            // if not present, generate a new key
+            String key = PluginUtils.extractKey(retrievePluginConfigurationRequest.getPluginConfiguration());
+            if (PluginUtils.isEmpty(key)){
                 key = rsaUtils.generateKey();
-            } else {
-                key = PluginUtils.extractKey(retrievePluginConfigurationRequest.getPluginConfiguration());
             }
 
             return banks.toString() + PluginUtils.SEPARATOR + key;

--- a/src/main/java/com/payline/payment/natixis/service/impl/PaymentFormConfigurationServiceImpl.java
+++ b/src/main/java/com/payline/payment/natixis/service/impl/PaymentFormConfigurationServiceImpl.java
@@ -36,8 +36,8 @@ public class PaymentFormConfigurationServiceImpl extends LogoPaymentFormConfigur
                 throw new InvalidDataException("Plugin configuration must not be null");
             }
             final List<SelectOption> banks = new ArrayList<>();
-            String BankList = PluginUtils.extractBanks(paymentFormConfigurationRequest.getPluginConfiguration());
-            for (Bank bank : NatixisBanksResponse.fromJson(BankList).getList()) {
+            String bankList = PluginUtils.extractBanks(paymentFormConfigurationRequest.getPluginConfiguration());
+            for (Bank bank : NatixisBanksResponse.fromJson(bankList).getList()) {
                 banks.add(SelectOption.SelectOptionBuilder.aSelectOption().withKey(bank.getBic()).withValue(bank.getName()).build());
             }
 

--- a/src/main/java/com/payline/payment/natixis/service/impl/WalletServiceImpl.java
+++ b/src/main/java/com/payline/payment/natixis/service/impl/WalletServiceImpl.java
@@ -1,5 +1,6 @@
 package com.payline.payment.natixis.service.impl;
 
+import com.payline.payment.natixis.exception.InvalidDataException;
 import com.payline.payment.natixis.exception.PluginException;
 import com.payline.payment.natixis.utils.PluginUtils;
 import com.payline.payment.natixis.utils.security.RSAUtils;
@@ -48,7 +49,10 @@ public class WalletServiceImpl implements WalletService {
             String bic = walletCreateRequest.getPaymentFormContext().getPaymentFormParameter().get(BankTransferForm.BANK_KEY);
 
             // encrypt it
-            String key = PluginUtils.extractKey(walletCreateRequest.getPluginConfiguration()).trim();
+            String key = PluginUtils.extractKey(walletCreateRequest.getPluginConfiguration());
+            if (key == null){
+                throw new InvalidDataException("No key in pluginConfiguration");
+            }
             String paymentData = rsaUtils.encrypt(bic, key);
 
             // create wallet

--- a/src/main/java/com/payline/payment/natixis/utils/PluginUtils.java
+++ b/src/main/java/com/payline/payment/natixis/utils/PluginUtils.java
@@ -137,15 +137,18 @@ public class PluginUtils {
     }
 
     private static String extract(String s, int i) {
-        return s.split(SEPARATOR)[i];
+        try {
+            return s.split(SEPARATOR)[i];
+        }catch (ArrayIndexOutOfBoundsException e){
+            return null;    // don't throw Exception but return null
+        }
     }
 
     public static String extractBanks(String s) {
         return extract(s, 0);
     }
 
-    public static String extractKey(String s) {
-        return extract(s, 1);
+    public static String extractKey(String s) { return extract(s, 1);
 
     }
 

--- a/src/main/java/com/payline/payment/natixis/utils/http/NatixisHttpClient.java
+++ b/src/main/java/com/payline/payment/natixis/utils/http/NatixisHttpClient.java
@@ -429,7 +429,7 @@ public class NatixisHttpClient {
 
         while( strResponse == null && attempts <= this.retries ){
             if( LOGGER.isDebugEnabled() ){
-                LOGGER.debug( "Start call to partner API (attempt {}) :" + System.lineSeparator() + PluginUtils.requestToString( httpRequest ), attempts );
+                LOGGER.debug( "Start call to partner API (attempt {}) :{}", attempts, System.lineSeparator() + PluginUtils.requestToString( httpRequest ) );
             } else {
                 LOGGER.info( "Start call to partner API [{} {}] (attempt {})", httpRequest.getMethod(), httpRequest.getURI(), attempts );
             }

--- a/src/main/java/com/payline/payment/natixis/utils/security/RSAUtils.java
+++ b/src/main/java/com/payline/payment/natixis/utils/security/RSAUtils.java
@@ -48,8 +48,7 @@ public class RSAUtils {
     private SecretKey getKey(String key) {
         byte[] decodedKey = Base64.getDecoder().decode(key);
         // rebuild key using SecretKeySpec
-        SecretKey secretKey = new SecretKeySpec(decodedKey, ALGORITHM);
-        return secretKey;
+        return new SecretKeySpec(decodedKey, ALGORITHM);
     }
 
 

--- a/src/test/java/com/payline/payment/natixis/service/impl/WalletServiceImplTest.java
+++ b/src/test/java/com/payline/payment/natixis/service/impl/WalletServiceImplTest.java
@@ -118,8 +118,8 @@ class WalletServiceImplTest {
 
         Assertions.assertEquals(WalletCreateResponseFailure.class, response.getClass());
         WalletCreateResponseFailure responseFailure = (WalletCreateResponseFailure) response;
-        Assertions.assertEquals(FailureCause.INTERNAL_ERROR, responseFailure.getFailureCause());
-        Assertions.assertEquals("plugin error: ArrayIndexOutOfBoundsException: 1", responseFailure.getErrorCode());
+        Assertions.assertEquals(FailureCause.INVALID_DATA, responseFailure.getFailureCause());
+        Assertions.assertEquals("No key in pluginConfiguration", responseFailure.getErrorCode());
     }
 
     @Test


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/41673610/89512187-265e3180-d7d3-11ea-8a16-1a7c45a3bd39.png)


la vulnérabilité viens du chiffrement AES ( Cipher.getInstance(AES) )

Les security hotspots viennent datent d'octobre 2019 et viennent de cette méthode:
   ```
 public static String jsonMinify( String json ){
        return json.trim()
                // remove line breaks and tabulations
                .replaceAll("[\\n\\r\\t]+\\s*", "")
                // remove spaces around properties name/value colon separator
                .replaceAll("\"\\s*:\\s*([{\\[\"]+)", "\":$1")
                // remove spaces around properties separator
                .replaceAll("([\"\\]}]+)\\s*,\\s*([\"\\[{]+)", "$1,$2")
                // remove spaces between closing brackets
                .replaceAll("([}\\]]+)\\s+([}\\]]+)", "$1$2");
    }
```
et de `MessageDigest.getInstance("SHA-256")`

Et les codes smells, pour ceux qu'il restent, ne sont pas génants et difficilement resolvables